### PR TITLE
Deprecate auth_token flow, use id_token instead. [v1]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
 language: android
+sudo: false
+jdk:
+  - oraclejdk8
 android:
   components:
-  - build-tools-23.0.1
-  - android-23
+  - tools
+  - build-tools-24.0.2
+  - android-24
   - extra-google-google_play_services
   - extra-google-m2repository
   - extra-android-m2repository
-  - addon-google_apis-google-23
+  - addon-google_apis-google-24
 script:
-- "./gradlew clean check --continue"
+  - "./gradlew clean test --continue"
 branches:
   only:
   - master

--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@ Lock-GooglePlus helps you integrate native Login with [Google+ Android SDK](http
 
 ## Requierements
 
-Android 4.0 or later & Google Play Services 8.+
+Android 4.0 or later & Google Play Services 9.+
 
 ## Before you start using Lock-Google
 
 In order to use Google APIs you'll need to register your Android application in [Google Developer Console](https://console.developers.google.com/project) and get your clientId.
-We recommend follwing Google's [quickstart](https://developers.google.com/mobile/add?platform=android), just pick `Google Sign-In`. Then with your OAuth Mobile clientID from Google, the only step missing is to configure your Google Connection in [Auth0 Dashboard](https://manage.auth0.com/#/connections/social) with your recenlty created Google clientId.
+We recommend following Google's [quickstart](https://developers.google.com/mobile/add?platform=android), just pick `Google Sign-In`. Then with your OAuth Mobile clientID from Google, the only step missing is to configure your Google Connection in [Auth0 Dashboard](https://manage.auth0.com/#/connections/social) with your recently created Google clientId.
 
 
 > For more information please check Google's [documentation](https://developers.google.com/identity/sign-in/android/)
 
 ### Auth0 Connection with multiple Google clientIDs (Web & Mobile)
 
-If you also have a Web Application, and a Google clientID & secret for it configured in Auth0, you need to whitelist the Google clientID of your mobile application in your Auth0 connection. With your Mobile clientID from Google, go to [Social Connections](https://manage.auth0.com/#/connections/social), select **Google** and add the clientID to the field named `Allowed Mobile Client IDs`
+If you also have a Web Application, and a Google clientID & secret for it configured in Auth0, you need to whitelist the Google clientID of your mobile application in your Auth0 connection. You will also need to create a new Credential for an **OAuth 2.0 Web Client** and save the `server_client_id` as it will be required in the next steps when you instantiate the `GoogleIdentityProvider`. With your Mobile clientID from Google, go to [Social Connections](https://manage.auth0.com/#/connections/social), select **Google** and add the clientID to the field named `Allowed Mobile Client IDs`. Next, add the Web clientID to the field named `Client ID`.
 
 ## Install
 
@@ -69,10 +69,10 @@ where `provider` is your instance of `GoogleIdentityProvider`
 
 ## Usage
 
-Just create a new instance of `GoogleIdentityProvider`
+Just create a new instance of `GoogleIdentityProvider` passing the Context and the `server_client_id` created in one of the previous steps.
 
 ```java
-GoogleIdentityProvider google = new GoogleIdentityProvider();
+GoogleIdentityProvider google = new GoogleIdentityProvider(context, "server_client_id");
 ```
 
 and register it with your instance of `Lock`

--- a/app/src/main/java/com/auth0/google/app/MainActivity.java
+++ b/app/src/main/java/com/auth0/google/app/MainActivity.java
@@ -65,7 +65,7 @@ public class MainActivity extends AppCompatActivity {
         Auth0 auth0 = new Auth0(getString(R.string.auth0_client_id), getString(R.string.auth0_domain_name));
         final AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
-        provider = new GoogleIdentityProvider(getApplicationContext());
+        provider = new GoogleIdentityProvider(getApplicationContext(), "SERVER_CLIENT_ID");
         provider.setCallback(new IdentityProviderCallback() {
             @Override
             public void onFailure(Dialog dialog) {

--- a/app/src/main/java/com/auth0/google/app/MainActivity.java
+++ b/app/src/main/java/com/auth0/google/app/MainActivity.java
@@ -28,6 +28,7 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AlertDialog;
@@ -52,7 +53,6 @@ public class MainActivity extends AppCompatActivity {
     private static final String TAG = MainActivity.class.getName();
 
     private GoogleIdentityProvider provider;
-    private boolean authRequestInProgress;
     private ProgressDialog progressDialog;
 
     @Override
@@ -130,7 +130,6 @@ public class MainActivity extends AppCompatActivity {
                 new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        authRequestInProgress = true;
                         progressDialog = ProgressDialog.show(MainActivity.this, getString(R.string.progress_title), getString(R.string.progress_message));
                         provider.start(MainActivity.this, Strategies.GooglePlus.getName());
                     }
@@ -147,18 +146,16 @@ public class MainActivity extends AppCompatActivity {
                     }
                 }
         );
-
-
     }
 
     @Override
-    protected void onResume() {
-        super.onResume();
-
-        if (authRequestInProgress) {
-            authRequestInProgress = !provider.authorize(this, GoogleIdentityProvider.GOOGLE_PLUS_TOKEN_REQUEST_CODE, Activity.RESULT_OK, getIntent());
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (provider != null && provider.authorize(this, GoogleIdentityProvider.GOOGLE_PLUS_TOKEN_REQUEST_CODE, Activity.RESULT_OK, data)) {
+            return;
         }
+        super.onActivityResult(requestCode, resultCode, data);
     }
+
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {

--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,8 @@ allprojects {
 
 ext.libraries = [
         lock_identity_core: 'com.auth0.android:identity-core:1.18.0',
-        google_play_services_plus: 'com.google.android.gms:play-services-plus:8.4.0',
-        google_play_services_auth: 'com.google.android.gms:play-services-auth:8.4.0',
+        google_play_services_plus: 'com.google.android.gms:play-services-plus:9.4.0',
+        google_play_services_auth: 'com.google.android.gms:play-services-auth:9.4.0',
         app_compat: 'com.android.support:appcompat-v7:23.1.1',
         testing: [
             dependencies.create('junit:junit:4.11') {

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.1'
-        classpath 'com.github.dcendents:android-maven-plugin:1.2'
+        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
 }
 
@@ -20,8 +20,9 @@ allprojects {
 }
 
 ext.libraries = [
-        lock_identity_core: 'com.auth0.android:identity-core:1.17.1',
+        lock_identity_core: 'com.auth0.android:identity-core:1.18.0',
         google_play_services_plus: 'com.google.android.gms:play-services-plus:8.4.0',
+        google_play_services_auth: 'com.google.android.gms:play-services-auth:8.4.0',
         app_compat: 'com.android.support:appcompat-v7:23.1.1',
         testing: [
             dependencies.create('junit:junit:4.11') {
@@ -41,6 +42,6 @@ ext.libraries = [
 
 ext.compile = [
         minSdk: 15,
-        maxSdk: 23,
-        buildToolsVersion: "23.0.1"
+        maxSdk: 24,
+        buildToolsVersion: "24.0.2"
 ]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Dec 09 13:34:26 GMT-03:00 2014
+#Thu Sep 22 13:05:01 ART 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/lock-googleplus/build.gradle
+++ b/lock-googleplus/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile libraries.lock_identity_core
     compile libraries.app_compat
+    compile libraries.google_play_services_auth
     compile libraries.google_play_services_plus
 }
 

--- a/lock-googleplus/src/main/java/com/auth0/google/FetchTokenAsyncTask.java
+++ b/lock-googleplus/src/main/java/com/auth0/google/FetchTokenAsyncTask.java
@@ -39,21 +39,19 @@ import com.google.android.gms.auth.GoogleAuthUtil;
 import com.google.android.gms.auth.GooglePlayServicesAvailabilityException;
 import com.google.android.gms.auth.UserRecoverableAuthException;
 import com.google.android.gms.common.GooglePlayServicesUtil;
-import com.google.android.gms.common.api.GoogleApiClient;
-import com.google.android.gms.plus.Plus;
 
 import java.io.IOException;
 
 public class FetchTokenAsyncTask extends AsyncTask<String, Void, Object> {
 
     public static final String TAG = FetchTokenAsyncTask.class.getName();
-    private final GoogleApiClient apiClient;
     private final Activity context;
+    private final String email;
     private final IdentityProviderCallback callback;
 
-    public FetchTokenAsyncTask(GoogleApiClient apiClient, Activity context, IdentityProviderCallback callback) {
-        this.apiClient = apiClient;
+    public FetchTokenAsyncTask(Activity context, String email, IdentityProviderCallback callback) {
         this.context = context;
+        this.email = email;
         this.callback = callback;
     }
 
@@ -62,10 +60,11 @@ public class FetchTokenAsyncTask extends AsyncTask<String, Void, Object> {
     protected Object doInBackground(String... params) {
         FetchTokenResultHolder holder = null;
         try {
+            final String magicString = "oauth2:" + TextUtils.join(" ", params);
             String accessToken = GoogleAuthUtil.getToken(
                     context,
-                    Plus.AccountApi.getAccountName(apiClient),
-                    "oauth2:" + TextUtils.join(" ", params));
+                    email,
+                    magicString);
 
             holder = new FetchTokenResultHolder(accessToken);
         } catch (IOException transientEx) {

--- a/lock-googleplus/src/main/java/com/auth0/google/GoogleIdentityProvider.java
+++ b/lock-googleplus/src/main/java/com/auth0/google/GoogleIdentityProvider.java
@@ -39,29 +39,29 @@ import java.util.List;
 
 /**
  * Google Identity Provider to authenticate with native SDK with full support for Android M permission model.
- *
+ * <p>
  * In order to create it, you just need an Android context
  * <pre><code>
  *  GoogleIdentityProvider provider = new GoogleIdentityProvider(context);
  *  this.provider = provider;
  * </code></pre>
- *
+ * <p>
  * Then just set the callback
- *
+ * <p>
  * <pre><code>
  *  IdentityProviderCallback callback = ...
  *  provider.setCallback(callback);
  * </code></pre>
- *
+ * <p>
  * And start authentication from any of your Activities
- *
+ * <p>
  * <pre><code>
  *  provider.start(this, "{connection name}");
  *  this.authenticationInProgress = true;
  * </code></pre>
- *
+ * <p>
  * Then you need to pass along the result from {@link Activity#onResume()} and permission result from {@link Activity#onRequestPermissionsResult(int, String[], int[])}
- *
+ * <p>
  * <pre><code>
  *  @Override
  *  protected void onResume() {
@@ -85,9 +85,13 @@ import java.util.List;
 @TargetApi(23)
 public class GoogleIdentityProvider extends AuthorizedIdentityProvider {
 
-    @SuppressWarnings("deprecated")
+    @Deprecated
     public GoogleIdentityProvider(Context context) {
-        super(new GooglePlusIdentityProvider(context));
+        this(context, null);
+    }
+
+    public GoogleIdentityProvider(Context context, String serverClientId) {
+        super(new GooglePlusIdentityProvider(context, serverClientId));
     }
 
     @Override

--- a/lock-googleplus/src/main/java/com/auth0/google/GoogleIdentityProvider.java
+++ b/lock-googleplus/src/main/java/com/auth0/google/GoogleIdentityProvider.java
@@ -29,6 +29,7 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.support.annotation.NonNull;
 import android.support.v7.app.AlertDialog;
 
 import com.auth0.googleplus.GooglePlusIdentityProvider;
@@ -86,11 +87,12 @@ import java.util.List;
 public class GoogleIdentityProvider extends AuthorizedIdentityProvider {
 
     @Deprecated
-    public GoogleIdentityProvider(Context context) {
+    public GoogleIdentityProvider(@NonNull Context context) {
+        //noinspection ConstantConditions
         this(context, null);
     }
 
-    public GoogleIdentityProvider(Context context, String serverClientId) {
+    public GoogleIdentityProvider(@NonNull Context context, @NonNull String serverClientId) {
         super(new GooglePlusIdentityProvider(context, serverClientId));
     }
 

--- a/lock-googleplus/src/main/java/com/auth0/googleplus/GooglePlusIdentityProvider.java
+++ b/lock-googleplus/src/main/java/com/auth0/googleplus/GooglePlusIdentityProvider.java
@@ -30,6 +30,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.util.Log;
 
 import com.auth0.core.Application;
@@ -39,10 +40,17 @@ import com.auth0.google.R;
 import com.auth0.identity.IdentityProvider;
 import com.auth0.identity.IdentityProviderCallback;
 import com.auth0.identity.IdentityProviderRequest;
+import com.google.android.gms.auth.api.Auth;
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
+import com.google.android.gms.auth.api.signin.GoogleSignInResult;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
+import com.google.android.gms.common.Scopes;
 import com.google.android.gms.common.api.GoogleApiClient;
-import com.google.android.gms.plus.Plus;
+import com.google.android.gms.common.api.ResultCallback;
+import com.google.android.gms.common.api.Scope;
+import com.google.android.gms.common.api.Status;
 
 /**
  * Please use {@link com.auth0.google.GoogleIdentityProvider} instead that has support for Android M permission model.
@@ -57,14 +65,13 @@ public class GooglePlusIdentityProvider implements IdentityProvider, GoogleApiCl
     private Activity activity;
     private IdentityProviderCallback callback;
 
+    @Deprecated
     public GooglePlusIdentityProvider(Context context) {
-        this.apiClient = new GoogleApiClient.Builder(context)
-                .addConnectionCallbacks(this)
-                .addOnConnectionFailedListener(this)
-                .addApi(Plus.API)
-                .addScope(Plus.SCOPE_PLUS_PROFILE)
-                .useDefaultAccount()
-                .build();
+        this(context, null);
+    }
+
+    public GooglePlusIdentityProvider(Context context, String serverClientId) {
+        this.apiClient = createAPIClient(context, serverClientId);
     }
 
     @Override
@@ -85,7 +92,7 @@ public class GooglePlusIdentityProvider implements IdentityProvider, GoogleApiCl
         }
         authenticating = true;
         if (apiClient.isConnected()) {
-            fetchToken();
+            getGoogleAccount();
         } else {
             apiClient.connect();
         }
@@ -105,7 +112,7 @@ public class GooglePlusIdentityProvider implements IdentityProvider, GoogleApiCl
     public boolean authorize(Activity activity, int requestCode, int resultCode, Intent data) {
         this.activity = activity;
         if (resultCode == Activity.RESULT_CANCELED) {
-            Log.d(TAG, "User cannceled operation with code " + requestCode);
+            Log.d(TAG, "User canceled operation with code " + requestCode);
             authenticating = false;
             return false;
         }
@@ -115,12 +122,25 @@ public class GooglePlusIdentityProvider implements IdentityProvider, GoogleApiCl
                 apiClient.connect();
             }
             return true;
-        } else if(requestCode == GOOGLE_PLUS_TOKEN_REQUEST_CODE) {
+        } else if (requestCode == GOOGLE_PLUS_TOKEN_REQUEST_CODE) {
             Log.v(TAG, "Received token request activity result " + resultCode);
             if (!apiClient.isConnected()) {
                 apiClient.connect();
             } else {
-                fetchToken();
+                if (resultCode == Activity.RESULT_OK) {
+                    final GoogleSignInResult result = Auth.GoogleSignInApi.getSignInResultFromIntent(data);
+
+                    if (result.isSuccess()) {
+                        final GoogleSignInAccount account = result.getSignInAccount();
+                        if (account.getIdToken() != null) {
+                            callback.onSuccess(Strategies.GooglePlus.getName(), account.getIdToken());
+                        } else {
+                            fetchToken(account.getEmail());
+                        }
+                    } else {
+                        callback.onFailure(R.string.com_auth0_google_authentication_failed_title, R.string.com_auth0_google_authentication_failed_message, null);
+                    }
+                }
             }
         }
         return authenticating;
@@ -129,13 +149,18 @@ public class GooglePlusIdentityProvider implements IdentityProvider, GoogleApiCl
     @Override
     public void clearSession() {
         try {
-            if (apiClient.isConnected()) {
-                Plus.AccountApi.clearDefaultAccount(apiClient);
-            }
+            Auth.GoogleSignInApi.signOut(apiClient).setResultCallback(new ResultCallback<Status>() {
+                @Override
+                public void onResult(@NonNull Status status) {
+                    if (!status.isSuccess()) {
+                        Log.w(TAG, "Couldn't clear account and credentials");
+                    }
+                }
+            });
         } catch (IllegalStateException e) {
-            Log.e(TAG, "Failed to clear G+ Session", e);
+            Log.e(TAG, "Failed to clear Google Plus Session", e);
         } finally {
-            if (apiClient.isConnected()) {
+            if (apiClient != null && apiClient.isConnected()) {
                 apiClient.disconnect();
             }
             activity = null;
@@ -144,7 +169,7 @@ public class GooglePlusIdentityProvider implements IdentityProvider, GoogleApiCl
 
     @Override
     public void onConnected(Bundle bundle) {
-        fetchToken();
+        getGoogleAccount();
         requestedLogin = false;
     }
 
@@ -187,6 +212,21 @@ public class GooglePlusIdentityProvider implements IdentityProvider, GoogleApiCl
         }
     }
 
+    private GoogleApiClient createAPIClient(Context context, String serverClientId) {
+        final GoogleSignInOptions.Builder gsoBuilder = new GoogleSignInOptions.Builder()
+                .requestScopes(new Scope(Scopes.PLUS_LOGIN))
+                .requestEmail()
+                .requestProfile();
+        if (serverClientId != null) {
+            gsoBuilder.requestIdToken(serverClientId);
+        }
+        GoogleSignInOptions gso = gsoBuilder.build();
+
+        return new GoogleApiClient.Builder(context, this, this)
+                .addApi(Auth.GOOGLE_SIGN_IN_API, gso)
+                .build();
+    }
+
     private void requestAuthentication(ConnectionResult result) {
         if (authenticating) {
             Log.v(TAG, "Showing G+ consent activity to the user");
@@ -202,7 +242,12 @@ public class GooglePlusIdentityProvider implements IdentityProvider, GoogleApiCl
         }
     }
 
-    private void fetchToken() {
-        new FetchTokenAsyncTask(apiClient, activity, callback).execute("email", "profile");
+    private void getGoogleAccount() {
+        final Intent signInIntent = Auth.GoogleSignInApi.getSignInIntent(apiClient);
+        activity.startActivityForResult(signInIntent, GOOGLE_PLUS_TOKEN_REQUEST_CODE);
+    }
+
+    private void fetchToken(String email) {
+        new FetchTokenAsyncTask(activity, email, callback).execute("https://www.googleapis.com/auth/plus.login", "email", "profile");
     }
 }

--- a/lock-googleplus/src/main/java/com/auth0/googleplus/GooglePlusIdentityProvider.java
+++ b/lock-googleplus/src/main/java/com/auth0/googleplus/GooglePlusIdentityProvider.java
@@ -66,11 +66,12 @@ public class GooglePlusIdentityProvider implements IdentityProvider, GoogleApiCl
     private IdentityProviderCallback callback;
 
     @Deprecated
-    public GooglePlusIdentityProvider(Context context) {
+    public GooglePlusIdentityProvider(@NonNull Context context) {
+        //noinspection ConstantConditions
         this(context, null);
     }
 
-    public GooglePlusIdentityProvider(Context context, String serverClientId) {
+    public GooglePlusIdentityProvider(@NonNull Context context, @NonNull String serverClientId) {
         this.apiClient = createAPIClient(context, serverClientId);
     }
 


### PR DESCRIPTION
* Update to latest google play services lib. (9.4.0)
* Deprecate both constructors receiving just the `context`, as they were using the `auth_token` flow now [deprecated by Google](https://developers.google.com/identity/sign-in/android/migration-guide#migrate_from_access_token_anti-pattern).
* Add constructor with the `server_client_id` value, mandatory for the `id_token` flow.
* Fix issue when coming back to the activity with a result.